### PR TITLE
Other dbs

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -20,8 +20,8 @@ common_param_env_vars_enabled: true
 param_container_name: "{{ project_name }}"
 param_usage_include_env: true
 param_env_vars:
-  - { env_var: "DB_HOST", env_value: "<hostname or ip>", desc: "Host address of mysql database" }
-  - { env_var: "DB_PORT", env_value: "3306", desc: "Port to access mysql database default is 3306" }
+  - { env_var: "DB_HOST", env_value: "<hostname or ip>", desc: "Host address of mariadb database" }
+  - { env_var: "DB_PORT", env_value: "3306", desc: "Port to access mariadb database default is 3306" }
   - { env_var: "DB_USER", env_value: "hedgedoc", desc: "Database user" }
   - { env_var: "DB_PASS", env_value: "<secret password>", desc: "Database password" }
   - { env_var: "DB_NAME", env_value: "hedgedoc", desc: "Database name" }
@@ -32,7 +32,7 @@ opt_param_env_vars:
   - { env_var: "CMD_PROTOCOL_USESSL", env_value: "false", desc: "Set to `true` if accessing over https via reverse proxy." }
   - { env_var: "CMD_PORT", env_value: "3000", desc: "If you wish to access hedgedoc at a port different than 80, 443 or 3000, you need to set this to that port (ie. `CMD_PORT=5000`) and change the port mapping accordingly (5000:5000)." }
   - { env_var: "CMD_ALLOW_ORIGIN", env_value: "['localhost']", desc: "Comma-separated list of allowed hostnames"}
-  - { env_var: "CMD_DB_DIALECT", env_value: "", desc: "This variable allows using a database besides sqlite (if DB_HOST not set up) and mysql." }
+  - { env_var: "CMD_DB_DIALECT", env_value: "", desc: "This variable allows selecting a database engine (if DB_HOST not set up). Available options are: `mariadb`, `mysql`, `postgres`, `sqlite`." }
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/{{ project_name }}/config", desc: "Persistent config files" }
@@ -47,7 +47,7 @@ app_setup_block: |
 
   [Full list of HedgeDoc options](https://docs.hedgedoc.org/configuration/)
 
-  For convenience we provide a working example using Mysql as a backend in this document, if you do not wish to use our custom environment values or a Mysql database backend feel free to leverage any of the settings laid out in the link above.
+  For convenience we provide a working example using Mariadb as a backend in this document.
 
   To run behind a reverse proxy we have a [preconfigured config](https://github.com/linuxserver/reverse-proxy-confs/blob/master/hedgedoc.subdomain.conf.sample) using docker networking included in our [SWAG](https://github.com/linuxserver/docker-swag) image and you can read how to use this in the [Reverse Proxy Confs repository](https://github.com/linuxserver/reverse-proxy-confs/#how-to-use-these-reverse-proxy-configs)
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -52,6 +52,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "21.06.24:", desc: "Allow using `CMD_DB_DIALECT` to set up the `CMD_DB_URL`."}
   - { date: "06.06.24:", desc: "Rebase to Alpine 3.20."}
   - { date: "23.12.23:", desc: "Rebase to Alpine 3.19."}
   - { date: "18.06.23:", desc: "Rebase to Alpine 3.18, deprecate armhf as per [https://www.linuxserver.io/armhf](https://www.linuxserver.io/armhf)." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -32,6 +32,7 @@ opt_param_env_vars:
   - { env_var: "CMD_PROTOCOL_USESSL", env_value: "false", desc: "Set to `true` if accessing over https via reverse proxy." }
   - { env_var: "CMD_PORT", env_value: "3000", desc: "If you wish to access hedgedoc at a port different than 80, 443 or 3000, you need to set this to that port (ie. `CMD_PORT=5000`) and change the port mapping accordingly (5000:5000)." }
   - { env_var: "CMD_ALLOW_ORIGIN", env_value: "['localhost']", desc: "Comma-separated list of allowed hostnames"}
+  - { env_var: "CMD_DB_DIALECT", env_value: "", desc: "This variable allows using a database besides sqlite (if DB_HOST not set up) and mysql." }
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/{{ project_name }}/config", desc: "Persistent config files" }

--- a/root/etc/s6-overlay/s6-rc.d/svc-hedgedoc/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-hedgedoc/run
@@ -3,7 +3,7 @@
 
 # if user is using our env variables set the DB_URL
 if [[ -n ${DB_HOST+x} ]]; then
-    export CMD_DB_URL="mysql://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+    export CMD_DB_URL="${CMD_DB_DIALECT:-mysql}://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
 fi
 
 # set env var for sqlite if db url and db_host unset

--- a/root/etc/s6-overlay/s6-rc.d/svc-hedgedoc/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-hedgedoc/run
@@ -3,7 +3,7 @@
 
 # if user is using our env variables set the DB_URL
 if [[ -n ${DB_HOST+x} ]]; then
-    export CMD_DB_URL="${CMD_DB_DIALECT:-mysql}://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
+    export CMD_DB_URL="${CMD_DB_DIALECT:-mariadb}://${DB_USER}:${DB_PASS}@${DB_HOST}:${DB_PORT}/${DB_NAME}"
 fi
 
 # set env var for sqlite if db url and db_host unset


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
<!--- Before submitting a pull request please check the following -->

<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-hedgedoc/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
I allowed the variable `CMD_DB_DIALECT` to be used to setup the `CMD_URL_DB` in the hedgedoc service definition.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
The only way to customize the DB connection without leaking the database information in a compose file is to set up the variables: `FILE__DB_HOST`, `FILE__DB_NAME`, `FILE__DB_PASS`, `FILE__DB_USER`.

This however does not allow to use other databases beside MySQL, so I added the option to use the variable `CMD_DB_DIALECT` which is the specified method according to the hedgedoc documentation.

This defaults to mysql, so if the variable is not set-up, the container will work as of now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have built my hedgedoc instance using this changes, these changes allowed me to connect to a postgres database without leaking info in the compose file.

## Source / References:

https://docs.hedgedoc.org/configuration/