### PR TITLE
fix: Add missing icu-data-full for TextDecoder support in NodeJS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN \
   apk add -U --no-cache \
     fontconfig \
     font-noto \
+    icu-data-full \
     nodejs-current && \
   apk add -U --no-cache --virtual=build-dependencies \
     build-base \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,6 +17,7 @@ RUN \
   apk add -U --no-cache \
     fontconfig \
     font-noto \
+    icu-data-full \
     nodejs-current && \
   apk add -U --no-cache --virtual=build-dependencies \
     build-base \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -93,6 +93,7 @@ init_diagram: |
   "hedgedoc:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "24.02.25:", desc: "Add missing icu-data-full to fix bug with TextDecoder and image uploads."}
   - {date: "21.06.24:", desc: "Allow using `CMD_DB_DIALECT` to set up the `CMD_DB_URL`."}
   - {date: "06.06.24:", desc: "Rebase to Alpine 3.20."}
   - {date: "23.12.23:", desc: "Rebase to Alpine 3.19."}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-hedgedoc/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

This adds `icu-data-full` since some image uploads fail with an decoding error due to a broken call to the TextDecoder in NodeJS that expects legacy charset converters to be in place. in particular it wants to use `windows-1252` as seen in the upstream GitHub issue.

The upstream images are not affected, since they use static builds of NodeJS.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

It fixes a bug, that was reported upstream, due do the way this image is build. It doesn't appear in upstream builds. We hope this reduces the number of bug reports for this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I build both versions of the image, with and without the issue. The issue was reproducible by copying multiple cells from LibreOffice Calc into HedgeDoc, resulting in an image upload.

When the package wasn't installed, it would fail due to the unsupported `windows-1252` encoding.

After installing the package, it works as expected.

## Source / References:
https://github.com/hedgedoc/hedgedoc/issues/5982
https://matrix.to/#/!oaRMJImPLfUnnXzwnN:shivering-isles.com/$bM9FdN50dj7YHXNJYhApnPYNyta7rxoKQeeqJLCQgmI?via=matrix.org&via=envs.net&via=mozilla.org
